### PR TITLE
Fix infinite loop

### DIFF
--- a/sketch_oct28c/Game.h
+++ b/sketch_oct28c/Game.h
@@ -82,14 +82,14 @@ void TitleText(){
   if (!Audio) {
       if (showarrow > 168){ofs = 42;}
       ard.setCursor(0, 0);
-      for(char i = ofs; i < showarrow; i++) {
+      for(uint8_t i = ofs; i < showarrow; i++) {
           ard.print((char)pgm_read_byte(&TitleSequenceText[i]));
       }
       if (ard.everyXFrames(15)) {showarrow++;}
       if (showarrow > 192){Audio = true; showarrow = 0;}
   }
   else {
-      for(char i = 48; i < 192; i++) {
+      for(uint8_t i = 48; i < 192; i++) {
           ard.print((char)pgm_read_byte(&TitleSequenceText[i]));
       }
       sprites.drawOverwrite(0,64-showarrow,Logo,0);


### PR DESCRIPTION
`char` is signed by default an the Arduboy so it can't reach `192`.
The text drawing is still broken after this, but at least the game starts.